### PR TITLE
Adicionando validação de tamanho em CpfCnpj da Customer e Payer

### DIFF
--- a/grails-app/services/gocharges/CustomerService.groovy
+++ b/grails-app/services/gocharges/CustomerService.groovy
@@ -56,9 +56,7 @@ class CustomerService {
     private void validate(CustomerAdapter adapter) {
         validateNotNull(adapter)
 
-        if(adapter.cpfCnpj.length() < 11 || adapter.cpfCnpj.length() > 14) {
-            throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
-        }
+        validateCpfCnpj(adapter.cpfCnpj)
 
         Customer emailValidator = Customer.findByEmail(adapter.email)
 
@@ -92,6 +90,12 @@ class CustomerService {
         if(adapter.name.isBlank() || adapter.email.isBlank() || adapter.mobilePhone.isBlank()
                 || adapter.cpfCnpj.isBlank() || adapter.address.isBlank()) {
             throw new BusinessException("É preciso preencher todos os campos!")
+        }
+    }
+
+    private void validateCpfCnpj(String cpfCnpj) {
+        if(cpfCnpj.length() != 11 || cpfCnpj != 14){
+            throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
         }
     }
 }

--- a/grails-app/services/gocharges/CustomerService.groovy
+++ b/grails-app/services/gocharges/CustomerService.groovy
@@ -2,6 +2,7 @@ package gocharges
 
 import gocharges.customer.CustomerAdapter
 import gocharges.exception.BusinessException
+import gocharges.validator.CpfCnpjValidator
 import grails.gorm.transactions.Transactional
 
 @Transactional
@@ -59,7 +60,7 @@ class CustomerService {
     private void validate(CustomerAdapter adapter) {
         validateNotNull(adapter)
 
-        validateCpfCnpj(adapter.cpfCnpj)
+        CpfCnpjValidator.validate(adapter.cpfCnpj)
 
         Customer emailValidator = Customer.findByEmail(adapter.email)
 
@@ -96,9 +97,4 @@ class CustomerService {
         }
     }
 
-    private void validateCpfCnpj(String cpfCnpj) {
-        if(cpfCnpj.length() != 11 || cpfCnpj.length() != 14){
-            throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
-        }
-    }
 }

--- a/grails-app/services/gocharges/CustomerService.groovy
+++ b/grails-app/services/gocharges/CustomerService.groovy
@@ -94,7 +94,7 @@ class CustomerService {
     }
 
     private void validateCpfCnpj(String cpfCnpj) {
-        if(cpfCnpj.length() != 11 || cpfCnpj != 14){
+        if(cpfCnpj.length() != 11 || cpfCnpj.length() != 14){
             throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
         }
     }

--- a/grails-app/services/gocharges/CustomerService.groovy
+++ b/grails-app/services/gocharges/CustomerService.groovy
@@ -56,6 +56,10 @@ class CustomerService {
     private void validate(CustomerAdapter adapter) {
         validateNotNull(adapter)
 
+        if(adapter.cpfCnpj.length() < 11 || adapter.cpfCnpj.length() > 14) {
+            throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
+        }
+
         Customer emailValidator = Customer.findByEmail(adapter.email)
 
         if(emailValidator) {

--- a/grails-app/services/gocharges/PayerService.groovy
+++ b/grails-app/services/gocharges/PayerService.groovy
@@ -46,7 +46,7 @@ class PayerService {
     }
 
     private void validateCpfCnpj(String cpfCnpj) {
-        if(cpfCnpj.length() != 11 || cpfCnpj != 14){
+        if(cpfCnpj.length() != 11 || cpfCnpj.length() != 14){
             throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
         }
     }

--- a/grails-app/services/gocharges/PayerService.groovy
+++ b/grails-app/services/gocharges/PayerService.groovy
@@ -45,12 +45,16 @@ class PayerService {
         }
     }
 
+    private void validateCpfCnpj(String cpfCnpj) {
+        if(cpfCnpj.length() != 11 || cpfCnpj != 14){
+            throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
+        }
+    }
+
     private void validateSave(PayerAdapter adapter)  {
         validateNotNull(adapter)
 
-        if(adapter.cpfCnpj.length() < 11 || adapter.cpfCnpj.length() > 14) {
-            throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
-        }
+        validateCpfCnpj(adapter.cpfCnpj)
 
         Payer payer = Payer.findByEmail(adapter.email)
         if(payer) {

--- a/grails-app/services/gocharges/PayerService.groovy
+++ b/grails-app/services/gocharges/PayerService.groovy
@@ -18,7 +18,7 @@ class PayerService {
         payer.address = adapter.address
 
         if(!payer.save(failOnError:true)){
-            throw new BusinessException("Erro inesperado")
+            throw new BusinessException("Erro inesperado!")
         }
 
         return payer
@@ -27,7 +27,7 @@ class PayerService {
     public Payer delete(Long id) {
         Payer payer = Payer.get(id)
 
-        if (!payer) throw new BusinessException("Pagador não encontrado")
+        if (!payer) throw new BusinessException("Pagador não encontrado.")
 
         payer.delete(failOnError: true)
 
@@ -41,16 +41,20 @@ class PayerService {
     private void validateNotNull(PayerAdapter adapter) {
         if (adapter.email.isBlank() || adapter.name.isBlank() || adapter.mobilePhone.isBlank() ||
                 adapter.cpfCnpj.isBlank() || adapter.address.isBlank()) {
-            throw new BusinessException("É preciso preencher todos os campos")
+            throw new BusinessException("É preciso preencher todos os campos.")
         }
     }
 
     private void validateSave(PayerAdapter adapter)  {
         validateNotNull(adapter)
 
+        if(adapter.cpfCnpj.length() < 11 || adapter.cpfCnpj.length() > 14) {
+            throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
+        }
+
         Payer payer = Payer.findByEmail(adapter.email)
         if(payer) {
-            throw new BusinessException("Email já cadastrado")
+            throw new BusinessException("Email já cadastrado.")
         }
     }
 
@@ -59,13 +63,13 @@ class PayerService {
 
         Payer payer = findById(id)
         if (!payer) {
-            throw new BusinessException("Pagador não encontrado")
+            throw new BusinessException("Pagador não encontrado.")
         }
 
         payer = Payer.findByEmail(adapter.email)
 
         if (payer && payer.id != id) {
-            throw new BusinessException("E-mail já em uso")
+            throw new BusinessException("E-mail já em uso!")
         }
     }
 
@@ -80,7 +84,7 @@ class PayerService {
         payer.address = adapter.address
 
         if(!payer.save(failOnError:true)){
-            throw new BusinessException("Não foi possível salvar")
+            throw new BusinessException("Não foi possível salvar.")
         }
 
         return payer

--- a/grails-app/services/gocharges/PayerService.groovy
+++ b/grails-app/services/gocharges/PayerService.groovy
@@ -1,6 +1,7 @@
 package gocharges
 
 import gocharges.payer.adapter.PayerAdapter
+import gocharges.validator.CpfCnpjValidator
 import grails.gorm.transactions.Transactional
 import gocharges.exception.BusinessException
 
@@ -45,16 +46,11 @@ class PayerService {
         }
     }
 
-    private void validateCpfCnpj(String cpfCnpj) {
-        if(cpfCnpj.length() != 11 || cpfCnpj.length() != 14){
-            throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
-        }
-    }
 
     private void validateSave(PayerAdapter adapter)  {
         validateNotNull(adapter)
 
-        validateCpfCnpj(adapter.cpfCnpj)
+        CpfCnpjValidator.validate(adapter.cpfCnpj)
 
         Payer payer = Payer.findByEmail(adapter.email)
         if(payer) {

--- a/src/main/groovy/gocharges/validator/CpfCnpjValidator.groovy
+++ b/src/main/groovy/gocharges/validator/CpfCnpjValidator.groovy
@@ -1,0 +1,13 @@
+package gocharges.validator
+
+import gocharges.exception.BusinessException
+
+class CpfCnpjValidator {
+
+     public static void validate(String cpfCnpj) {
+        if(cpfCnpj.length() != 11 || cpfCnpj.length() != 14){
+            throw new BusinessException("Informe um tamanho de CPF / CNPJ correto.")
+        }
+    }
+
+}


### PR DESCRIPTION
### Impacto
- Implementando uma leve validação de tamanho de CpfCnpj que retorna uma exceção de negócio, evitando que o programa pare só porque o usuário digitou um valor com tamanho fora do padrão.

- As validações ainda precisam ser melhoradas nos próximos PRs

### PR Predecessora
- Não possui.