### PR TITLE
Customer cadastra Payers

### DIFF
--- a/grails-app/controllers/gocharges/PayerController.groovy
+++ b/grails-app/controllers/gocharges/PayerController.groovy
@@ -3,7 +3,6 @@ package gocharges
 import gocharges.exception.BusinessException
 import gocharges.payer.PayerRepository
 import gocharges.payer.adapter.PayerAdapter
-import grails.plugin.springsecurity.SpringSecurityService
 
 class PayerController {
 

--- a/grails-app/controllers/gocharges/PayerController.groovy
+++ b/grails-app/controllers/gocharges/PayerController.groovy
@@ -3,6 +3,7 @@ package gocharges
 import gocharges.exception.BusinessException
 import gocharges.payer.PayerRepository
 import gocharges.payer.adapter.PayerAdapter
+import grails.plugin.springsecurity.SpringSecurityService
 
 class PayerController {
 

--- a/grails-app/domain/gocharges/Payer.groovy
+++ b/grails-app/domain/gocharges/Payer.groovy
@@ -10,6 +10,8 @@ class Payer extends BaseEntity {
     String cpfCnpj
     String address
 
+    Customer customer
+
     static constraints = {
         name(blank:false)
         email(email:true, blank:false, unique:true)

--- a/grails-app/domain/gocharges/Payer.groovy
+++ b/grails-app/domain/gocharges/Payer.groovy
@@ -14,9 +14,9 @@ class Payer extends BaseEntity {
 
     static constraints = {
         name(blank:false)
-        email(email:true, blank:false, unique:true)
+        email(email:true, blank:false, unique:'customer')
         mobilePhone(blank:false)
-        cpfCnpj(blank:false, unique:true, size: 11..14)
+        cpfCnpj(blank:false, unique:'customer', size: 11..14)
         address(blank:false)
     }
 }

--- a/grails-app/services/gocharges/PayerService.groovy
+++ b/grails-app/services/gocharges/PayerService.groovy
@@ -5,9 +5,12 @@ import gocharges.payer.adapter.PayerAdapter
 import gocharges.validator.CpfCnpjValidator
 import grails.gorm.transactions.Transactional
 import gocharges.exception.BusinessException
+import grails.plugin.springsecurity.SpringSecurityService
 
 @Transactional
 class PayerService {
+
+    SpringSecurityService springSecurityService
 
     public Payer save(PayerAdapter adapter) {
         validateSave(adapter)
@@ -18,6 +21,7 @@ class PayerService {
         payer.mobilePhone = adapter.mobilePhone
         payer.cpfCnpj = adapter.cpfCnpj
         payer.address = adapter.address
+        payer.customer = springSecurityService.getCurrentUser().customer
 
         payer.save(failOnError:true)
         return payer
@@ -76,6 +80,7 @@ class PayerService {
     }
 
     public List<Payer> list() {
-        return PayerRepository.query([includeDeleted: false]).list()
+        Customer customer = springSecurityService.getCurrentUser().customer
+        return PayerRepository.query([includeDeleted: false, customer: customer]).list()
     }
 }

--- a/grails-app/services/gocharges/PayerService.groovy
+++ b/grails-app/services/gocharges/PayerService.groovy
@@ -1,6 +1,5 @@
 package gocharges
 
-import gocharges.customer.CustomerRepository
 import gocharges.payer.PayerRepository
 import gocharges.payer.adapter.PayerAdapter
 import gocharges.validator.CpfCnpjValidator

--- a/src/main/groovy/gocharges/payer/PayerRepository.groovy
+++ b/src/main/groovy/gocharges/payer/PayerRepository.groovy
@@ -21,6 +21,10 @@ class PayerRepository {
             if(search.containsKey("id")) {
                 eq("id", search.id)
             }
+
+            if(search.containsKey("customer")) {
+                eq("customer", search.customer)
+            }
         }
 
 

--- a/src/main/groovy/gocharges/payer/PayerRepository.groovy
+++ b/src/main/groovy/gocharges/payer/PayerRepository.groovy
@@ -6,6 +6,10 @@ import grails.gorm.DetachedCriteria
 class PayerRepository {
     public static DetachedCriteria<Payer> query(Map search) {
         DetachedCriteria<Payer> query = Payer.where {
+            if(!Boolean.valueOf(search.ignoreCustomer) && !search.containsKey("customer")) {
+                throw new RuntimeException("O atributo customer é obrigatório para executar a consulta.")
+            }
+
             if(search.containsKey("cpfCnpj")) {
                 eq("cpfCnpj", search.cpfCnpj)
             }


### PR DESCRIPTION
### Impacto
- Usuário:
    - pode cadastrar payers
    - não pode cadastrar payers com e-mail ou cpf/cnpj iguais ao dele
    - não pode cadastrar payers com e-mail ou cpf/cnpj iguais aos de payers já criados por ele

- Payer index agora lista apenas payers do usuário que está logado

### PR Predecessora
- https://github.com/pedrooalves/goCharges/pull/26