### PR TITLE
Renomeando métodos da TagLib

### DIFF
--- a/grails-app/taglib/gocharges/FormatTagLib.groovy
+++ b/grails-app/taglib/gocharges/FormatTagLib.groovy
@@ -7,15 +7,15 @@ class FormatTagLib {
 
     static namespace = "formatTagLib"
 
-    def brazilDateNotation = { Map attrs ->
+    def brazilDate = { Map attrs ->
         out << dateNotation("dd/MM/yyyy", attrs.date)
     }
 
-    def isoDateNotation = { Map attrs ->
+    def isoDate = { Map attrs ->
         out << dateNotation("yyyy-MM-dd", attrs.date)
     }
 
-    def billingTypeNotation = { Map attrs ->
+    def billingType = { Map attrs ->
         String messageCode = "BillingType." + attrs.billingType.toString()
         out << Utils.getMessageProperty(messageCode, null)
     }

--- a/grails-app/views/payment/edit.gsp
+++ b/grails-app/views/payment/edit.gsp
@@ -34,7 +34,7 @@
                     <div class="form-group mb-3">
                         <label class="mb-2">Data de Vencimento</label>
                         <input class="form-control" type="date" name="dueDate"
-                               value="${formatTagLib.isoDateNotation(date: payment.dueDate)}"/><br>
+                               value="${formatTagLib.isoDate(date: payment.dueDate)}"/><br>
                     </div>
 
                     <div class="form-group mb-3">

--- a/grails-app/views/payment/index.gsp
+++ b/grails-app/views/payment/index.gsp
@@ -29,7 +29,7 @@
                     <ul class="list-group list-group-horizontal mb-1 mb-1 justify-content-between">
                         <li class="custom-list-item col-3">${payment.billingType}</li>
                         <li class="custom-list-item col">${payment.value}</li>
-                        <li class="custom-list-item col"><formatTagLib:brazilDateNotation date="${payment.dueDate}"/></li>
+                        <li class="custom-list-item col"><formatTagLib:brazilDate date="${payment.dueDate}"/></li>
                         <li class="custom-list-item col">${payment.status}</li>
                         <li class="custom-list-item col">${payment.payer.name}</li>
 


### PR DESCRIPTION
### Impacto
- Renomeando métodos públicos da taglib para evitar duplicidade.

### Release Note (Descrição que irá no forno)

### PR Predecessora

### Plano de deploy
- Antes do deploy:
- Depois do deploy:

### Link da tarefa no JIRA / Trello

### Link dos mockups

### Prints do desenvolvimento
